### PR TITLE
Clean up python setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,6 @@ setuptools.setup(
     install_requires=[
         "flake8~=3.8",
     ],
+    dependency_links=[
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@ import setuptools
 # The same modules should appear in the requirements.txt file as given below.
 setuptools.setup(
     name='lib_xassert',
-    package_dir={'': 'lib/python'},
-    packages=setuptools.find_packages(where="lib/python"),
     install_requires=[
         "flake8~=3.8",
     ],


### PR DESCRIPTION
Remove incorrect arguments.  Add empty dependency_links list to the arguments for setup.  Use similar contents in all setup.py files.