### PR TITLE
Changed xassert.xc file to c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.swn
 *~
 *.DS_Store
+*.vscode
 
 # Python
 *.pyc

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_xassert change log
 ======================
 
+UNRELEASED
+----------
+  
+  * CHANGED: Replaced xassert.xc with xassert.c for better toolchain compatibility.
+
 4.3.3
 -----
 
@@ -68,4 +73,3 @@ lib_xassert change log
 -----
 
   * CHANGED: Restructured library
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,3 +73,4 @@ UNRELEASED
 -----
 
   * CHANGED: Restructured library
+

--- a/examples/app_assert/src/fn_assert.c
+++ b/examples/app_assert/src/fn_assert.c
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 XMOS LIMITED.
+// Copyright 2024-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define XASSERT_UNIT FN_ASSERT

--- a/examples/app_assert/src/fn_no_assert.c
+++ b/examples/app_assert/src/fn_no_assert.c
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 XMOS LIMITED.
+// Copyright 2024-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define XASSERT_UNIT FN_NO_ASSERT

--- a/examples/app_assert/src/main.c
+++ b/examples/app_assert/src/main.c
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 XMOS LIMITED.
+// Copyright 2024-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 extern void fn_no_assert(int x);

--- a/examples/app_fail/src/main.c
+++ b/examples/app_fail/src/main.c
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 XMOS LIMITED.
+// Copyright 2024-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define XASSERT_UNIT FN_FAIL

--- a/examples/app_unreachable/src/main.c
+++ b/examples/app_unreachable/src/main.c
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 XMOS LIMITED.
+// Copyright 2024-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define XASSERT_UNIT FN_UNREACHABLE

--- a/lib_xassert/api/xassert.h
+++ b/lib_xassert/api/xassert.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 XMOS LIMITED.
+// Copyright 2014-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef __xassert_h__
 #define __xassert_h__

--- a/lib_xassert/src/xassert.c
+++ b/lib_xassert/src/xassert.c
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 XMOS LIMITED.
+// Copyright 2014-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xassert.h"
 

--- a/lib_xassert/src/xassert.c
+++ b/lib_xassert/src/xassert.c
@@ -2,4 +2,12 @@
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xassert.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern inline int xassert_msg(const char msg[]);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/assert_test/src/main.xc
+++ b/tests/assert_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 XMOS LIMITED.
+// Copyright 2015-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #define XASSERT_ENABLE_DEBUG 1
 #define XASSERT_ENABLE_LINE_NUMBERS 1

--- a/tests/assert_test_unit/src/main.xc
+++ b/tests/assert_test_unit/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 XMOS LIMITED.
+// Copyright 2015-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #define XASSERT_UNIT TESTER
 #define XASSERT_ENABLE_DEBUG_TESTER 1

--- a/tests/fail_test/src/main.xc
+++ b/tests/fail_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 XMOS LIMITED.
+// Copyright 2015-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xassert.h>
 

--- a/tests/test_xassert.py
+++ b/tests/test_xassert.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 XMOS LIMITED.
+# Copyright 2015-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import subprocess

--- a/tests/unreachable_test/src/main.xc
+++ b/tests/unreachable_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 XMOS LIMITED.
+// Copyright 2015-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xassert.h>
 


### PR DESCRIPTION
closes (partially) [LSM-217](https://xmosjira.atlassian.net/browse/LSM-217?atlOrigin=eyJpIjoiOWY3ODE5N2M5NGQ3NDk0YjkwYjQwOWI3OWZhYmVmZTYiLCJwIjoiaiJ9)
- lib_xassert/src/xassert.xc  is used only for linkage reasons. It can be replaced with c. 
- updated copyright and changelog 

[LSM-217]: https://xmosjira.atlassian.net/browse/LSM-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ